### PR TITLE
Force feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.crx
 *.pem
+.idea

--- a/src/background.js
+++ b/src/background.js
@@ -1,19 +1,42 @@
-var authUser;
+var authUser, force;
+
 chrome.storage.sync.get({
     authuser: '',
+    force: false,
 }, function(result) {
     authUser = result.authuser;
+    force = result.force;
 });
+
 chrome.webRequest.onBeforeRequest.addListener(function (details) {
-    if (details.url.toLowerCase().indexOf('authuser') == -1 && 
-            /meet.google.com\/.*-.*-.*/.test(details.url) &&
-            details.method == "GET") {
-        var _redirectUrl = details.url;
-        var newArg = 'authuser=' + authUser;
-        _redirectUrl = _redirectUrl + (_redirectUrl.indexOf('?') == -1 ? '?' : '&') + newArg;
-        return {
-            redirectUrl: _redirectUrl
-        };
+    if( details.method === "GET" ) {
+        var loweredUrl = details.url.toLowerCase();
+
+        var authUserExists = loweredUrl.indexOf('authuser') >= 0;
+        var authUserIsSame = loweredUrl.indexOf('authuser=' + authUser) >= 0;
+
+        var shouldRedirect = ( !authUserExists  || (!authUserIsSame && force ) ) && parseInt(authUser) > 0;
+        var isRedirectUriCorrect = ( /meet.google.com\/.*-.*-.*/.test(details.url) || details.url === 'https://meet.google.com/' || 'https://meet.google.com/landing' || 'https://meet.google.com/new' );
+
+        if ( shouldRedirect && isRedirectUriCorrect ) {
+            var _redirectUrl = details.url;
+
+            var params = new URLSearchParams(_redirectUrl.split('?')[1]);
+
+            for (var pair of params.entries()) {
+                if( pair[0].toLowerCase() === "authuser" ) {
+                    params.delete(pair[0]);
+                }
+            }
+
+            params.set('authuser', authUser);
+
+            _redirectUrl = _redirectUrl.split('?')[0] + "?" + params.toString();
+
+            return {
+                redirectUrl: _redirectUrl
+            };
+        }
     }
 }, {
     urls: ["https://meet.google.com/*"] 

--- a/src/options.html
+++ b/src/options.html
@@ -9,22 +9,29 @@
 <body>
     <div class="container">
         <h3>Default Google Meet account Configuration</h3>
-        <p class="grouped">
+        <p>
             <input type="text" id="authuser" placeholder="Set the AuthUser">
+        </p>
+        <p>
+            <input type="checkbox" id="force" /> Force Redirect?
+        </p>
+        <p>
             <button id="save">Save</button>
         </p>
         <h3>What is an AuthUser ID?</h3>
-        <p>To find the authUser ID for the Google account you want to set as default:
+        <p>To find the authUser ID for the Google account you want to set as default:</p>
         <ul>
             <li>Go to meet.google.com</li>
             <li>Using the account switcher in the top right, switch to the google account you want as your default</li>
             <li>After the page reloads with the desired account active, there will be a <em>authuser=</em> section added
                 to
-                the url. The number that follows this is your authUser ID</li>
+                the url. The number that follows this is your AuthUser ID</li>
         </ul>
-        If the first account that Google Meet opened is your desired account, your authUser ID is 0 (and you probably
-        don't need this extension)
-        </p>
+        <p>If the first account that Google Meet opened is your desired account, your authUser ID is 0 (and you probably
+            don't need this extension)</p>
+        <h3>What is an Force Redirect?</h3>
+        <p>This option is required in order to handle invalid links with incorrect AuthUser inside it.</p>
+        <p>This option start to redirect you into AuthUser ID, no matter which AuthUse ID selected</p>
 
     </div>
     <script src="options.js"></script>

--- a/src/options.js
+++ b/src/options.js
@@ -1,13 +1,18 @@
 saveButton = document.getElementById('save');
 authuserInput = document.getElementById('authuser');
+forceInput = document.getElementById('force');
 
 function saveConfig() {
     chrome.storage.sync.set({
         authuser: authuserInput.value,
+        force: forceInput.checked === true
     }, function() {
         saveButton.setAttribute('class', 'button success');
         saveButton.innerHTML = "Saved";
+
         chrome.extension.getBackgroundPage().authUser = authuserInput.value;
+        chrome.extension.getBackgroundPage().force = forceInput.checked === true;
+
         setTimeout(function() {
             saveButton.removeAttribute('class');
             window.close();
@@ -27,10 +32,13 @@ function validateInput() {
 }
 
 function loadConfig() {
-    var initialValue = chrome.storage.sync.get({
+    chrome.storage.sync.get({
         authuser: '',
+        force: false
     }, function(result) {
         authuserInput.value = result.authuser;
+        forceInput.checked = result.force;
+
         validateInput();
     });
 }


### PR DESCRIPTION
There is a force feature for this plugin.

It enforces redirect to the correct AuthUser ID, no matters if there is some AuthUser ID already exists (only correct AuthUser ID prevents it from redirect).

Also, I made some chages, which allow to redirect to correct user id from links like:

https://meet.google.com/
https://meet.google.com/landing
https://meet.google.com/new