### PR TITLE
Allow to hide auth user parameter after redirection & some minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 A chrome extension for Google Meet users who are signed in to multiple active Google accounts. It allows you to set one of your Google accounts as the default when you click a Google Meet link (e.g. from a calendar event).
 
-If the link already has an 'authUser' argument, the extension will not manipulate it.
+If the link already has an 'authUser' argument, the extension will not manipulate it until use use 'force' option.
+
+There is also option for remove 'authUser' argument from url after redirection, to simplify URL sharing.
 
 Contributors:
 - [lesiki](https://github.com/lesiki)

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,66 @@
+{
+  "optionsTitle": {
+    "message": "Google Meet Default Account"
+  },
+  "optionsConfigurationTitle": {
+    "message": "Google Meet Default Account Configuration"
+  },
+  "authUserLabel": {
+    "message": "Auth User"
+  },
+  "authUserPlaceholder": {
+    "message": "Set the AuthUser"
+  },
+  "forceRedirectLabel": {
+    "message": "Force redirect?"
+  },
+  "hideAuthUserLabel": {
+    "message": "Hide AuthUser after redirection?"
+  },
+  "saveButtonText": {
+    "message": "Save"
+  },
+
+  "helpAuthUserIdTitle": {
+    "message": "What is an AuthUser ID?"
+  },
+  "helpAuthUserIdParagraphOne": {
+    "message": "To find the AuthUser ID for the Google account you want to set as default:"
+  },
+  "helpAuthUserIdParagraphTwo": {
+    "message": "Go to <a href='https://meet.google.com/' target='_blank'>meet.google.com</a>"
+  },
+  "helpAuthUserIdParagraphThree": {
+    "message": "Using the account switcher in the top right, switch to the google account you want as your default"
+  },
+  "helpAuthUserIdParagraphFour": {
+    "message": "After the page reloads with the desired account active, there will be a <em>authuser=</em> section added to the url. The number that follows this is your AuthUser ID"
+  },
+  "helpAuthUserIdParagraphFive": {
+    "message": "If the first account that Google Meet opened is your desired account, your AuthUser ID is 0 (and you probably don't need this extension)"
+  },
+
+  "helpForceRedirectTitle": {
+    "message": "What is an Force Redirect?"
+  },
+  "helpForceRedirectParagraphOne": {
+    "message": "This option is required in order to handle invalid links with incorrect AuthUser inside it."
+  },
+  "helpForceRedirectParagraphTwo": {
+    "message": "This option start to redirect you into AuthUser ID, no matter which AuthUse ID provided in URL."
+  },
+
+  "helpHideAuthUserTitle": {
+    "message": "What is an Hide AuthUser after redirection?"
+  },
+  "helpHideAuthUserParagraphOne": {
+    "message": "This option helps you to remove ?authuser= after redirection from url, so you can easily share it to others by copy/pasting."
+  },
+
+  "saveButtonSaving": {
+    "message": "Saving..."
+  },
+  "saveButtonSaved": {
+    "message": "Saved"
+  }
+}

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,0 +1,66 @@
+{
+  "optionsTitle": {
+    "message": "Google Meet Default Account"
+  },
+  "optionsConfigurationTitle": {
+    "message": "Google Meet Default Account Настройки"
+  },
+  "authUserLabel": {
+    "message": "Auth User"
+  },
+  "authUserPlaceholder": {
+    "message": "Настройте AuthUser"
+  },
+  "forceRedirectLabel": {
+    "message": "Всегда перенаправлять?"
+  },
+  "hideAuthUserLabel": {
+    "message": "Скрыть AuthUser после перенаправления?"
+  },
+  "saveButtonText": {
+    "message": "Сохранить"
+  },
+
+  "helpAuthUserIdTitle": {
+    "message": "Что такое AuthUser ID?"
+  },
+  "helpAuthUserIdParagraphOne": {
+    "message": "Чтобы понять, какой AuthUser ID для аккаунта Google вам необходимо установить, следуйте инструкциям:"
+  },
+  "helpAuthUserIdParagraphTwo": {
+    "message": "Перейдите по ссылке <a href='https://meet.google.com/' target='_blank'>meet.google.com</a>"
+  },
+  "helpAuthUserIdParagraphThree": {
+    "message": "Используя переключатель аккаунтов в правом верхнем углу, переключитесь на тот аккаунт, который вы хотите установить по умолчанию"
+  },
+  "helpAuthUserIdParagraphFour": {
+    "message": "После перезагрузки страницы с необходимым аккаунтов вы увидите параметр <em>authuser=</em> в URL. Число, которое следует за этим параметром и есть ваш AuthUser ID"
+  },
+  "helpAuthUserIdParagraphFive": {
+    "message": "Если страница открылась сразу же с необходимым аккаунтом, то ваш AuthUser ID является 0 (и, возможно, вам не нужно это расширение)"
+  },
+
+  "helpForceRedirectTitle": {
+    "message": "Что означает 'Всегда перенаправлять'?"
+  },
+  "helpForceRedirectParagraphOne": {
+    "message": "Эта опция необходима, если кто-либо отправляет вам ссылки с некорректным AuthUser ID в них."
+  },
+  "helpForceRedirectParagraphTwo": {
+    "message": "После её включения, даже с таких ссылок будет происходить редирект на выбранный вами аккаунт."
+  },
+
+  "helpHideAuthUserTitle": {
+    "message": "Что означает 'Скрыть AuthUser после перенаправления'?"
+  },
+  "helpHideAuthUserParagraphOne": {
+    "message": "Эта опция автоматически удаляет параметр ?authuser из итоговой ссылки, после чего вы можете без проблем отправить её другому человеку без этого параметра."
+  },
+
+  "saveButtonSaving": {
+    "message": "Созраняю..."
+  },
+  "saveButtonSaved": {
+    "message": "Сохранено"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -2,26 +2,24 @@ var authUser, force;
 
 chrome.storage.sync.get({
     authuser: '',
-    force: false,
+    force: false
 }, function(result) {
     authUser = result.authuser;
     force = result.force;
 });
 
 chrome.webRequest.onBeforeRequest.addListener(function (details) {
-    if( details.method === "GET" ) {
+    if( details.method === "GET" && details.type === "main_frame" ) {
         var loweredUrl = details.url.toLowerCase();
 
         var authUserExists = loweredUrl.indexOf('authuser') >= 0;
-        var authUserIsSame = loweredUrl.indexOf('authuser=' + authUser) >= 0;
+        var authUserIsSame = authUserExists && loweredUrl.indexOf('authuser=' + authUser) >= 0;
 
         var shouldRedirect = ( !authUserExists  || (!authUserIsSame && force ) ) && parseInt(authUser) > 0;
         var isRedirectUriCorrect = ( /meet.google.com\/.*-.*-.*/.test(details.url) || details.url === 'https://meet.google.com/' || 'https://meet.google.com/landing' || 'https://meet.google.com/new' );
 
         if ( shouldRedirect && isRedirectUriCorrect ) {
-            var _redirectUrl = details.url;
-
-            var params = new URLSearchParams(_redirectUrl.split('?')[1]);
+            var params = new URLSearchParams(details.url.split('?')[1]);
 
             for (var pair of params.entries()) {
                 if( pair[0].toLowerCase() === "authuser" ) {
@@ -31,13 +29,11 @@ chrome.webRequest.onBeforeRequest.addListener(function (details) {
 
             params.set('authuser', authUser);
 
-            _redirectUrl = _redirectUrl.split('?')[0] + "?" + params.toString();
-
             return {
-                redirectUrl: _redirectUrl
+                redirectUrl: details.url.split('?')[0] + "?" + params.toString()
             };
         }
     }
 }, {
     urls: ["https://meet.google.com/*"] 
-}, ["blocking"]); 
+}, ["blocking"]);

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,0 +1,9 @@
+if( window.location.href.toLowerCase().indexOf("authuser=") >= 0 ) {
+    chrome.storage.sync.get({
+        hideAuthUser: false,
+    }, function(result) {
+        if( result.hideAuthUser ) {
+            window.history.replaceState({}, document.title, window.location.pathname);
+        }
+    });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,13 @@
 	"background": {
 		"scripts": ["background.js"]
     },
+    "content_scripts": [
+        {
+            "matches": ["https://meet.google.com/*"],
+            "js": ["contentScript.js"]
+        }
+    ],
+    "default_locale": "en",
     "options_ui": {
         "page": "options.html",
         "open_in_tab": false

--- a/src/options.html
+++ b/src/options.html
@@ -2,39 +2,74 @@
 <html>
 
 <head>
-    <title>Google Meet Default Account</title>
-    <link rel="stylesheet" href="https://unpkg.com/chota@latest">
+    <title data-localize="__MSG_optionsTitle__">Google Meet Default Account</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
-<body>
-    <div class="container">
-        <h3>Default Google Meet account Configuration</h3>
-        <p>
-            <input type="text" id="authuser" placeholder="Set the AuthUser">
-        </p>
-        <p>
-            <input type="checkbox" id="force" /> Force Redirect?
-        </p>
-        <p>
-            <button id="save">Save</button>
-        </p>
-        <h3>What is an AuthUser ID?</h3>
-        <p>To find the authUser ID for the Google account you want to set as default:</p>
-        <ul>
-            <li>Go to meet.google.com</li>
-            <li>Using the account switcher in the top right, switch to the google account you want as your default</li>
-            <li>After the page reloads with the desired account active, there will be a <em>authuser=</em> section added
-                to
-                the url. The number that follows this is your AuthUser ID</li>
-        </ul>
-        <p>If the first account that Google Meet opened is your desired account, your authUser ID is 0 (and you probably
-            don't need this extension)</p>
-        <h3>What is an Force Redirect?</h3>
-        <p>This option is required in order to handle invalid links with incorrect AuthUser inside it.</p>
-        <p>This option start to redirect you into AuthUser ID, no matter which AuthUse ID selected</p>
-
+<body style="width: 600px">
+<div class="container" style="width: 90%">
+    <div class="row">
+        <div class="col s12">
+            <h5 data-localize="__MSG_optionsConfigurationTitle__">Google Meet Default Account Configuration</h5>
+        </div>
     </div>
-    <script src="options.js"></script>
+
+    <div class="row">
+        <form class="col s12">
+            <div class="row">
+                <div class="input-field col s12">
+                    <span data-localize="__MSG_authUserLabel__">Auth User</span>
+                    <input placeholder="Set the AuthUser" data-placeholder-localize="__MSG_authUserPlaceholder__" id="authuser" type="text" />
+                </div>
+            </div>
+            <div class="row">
+                <div class="сol s12">
+                    <label>
+                        <input type="checkbox" id="force" />
+                        <span data-localize="__MSG_forceRedirectLabel__">Force redirect?</span>
+                    </label>
+                </div>
+            </div>
+            <div class="row">
+                <div class="сol s12">
+                    <label>
+                        <input type="checkbox" id="hideAuthUser" />
+                        <span data-localize="__MSG_hideAuthUserLabel__">Hide AuthUser after redirection?</span>
+                    </label>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s12">
+                    <button class="btn" id="save" data-localize="__MSG_saveButtonText__">Save</button>
+                    <span id="saved" class="flow-text" style="margin-left: 5px;"></span>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <h5 data-localize="__MSG_helpAuthUserIdTitle__">What is an AuthUser ID?</h5>
+    <p class="flow-text" data-localize="__MSG_helpAuthUserIdParagraphOne__">To find the AuthUser ID for the Google account you want to set as default:</p>
+    <ul class="collection">
+        <li class="collection-item flow-text" data-localize="__MSG_helpAuthUserIdParagraphTwo__">Go to <a href='https://meet.google.com/' target='_blank'>meet.google.com</a></li>
+        <li class="collection-item flow-text" data-localize="__MSG_helpAuthUserIdParagraphThree__">Using the account switcher in the top right, switch to the google account you want
+            as your default
+        </li>
+        <li class="collection-item flow-text" data-localize="__MSG_helpAuthUserIdParagraphFour__">After the page reloads with the desired account active, there will be a <em>authuser=</em>
+            section added
+            to
+            the url. The number that follows this is your AuthUser ID
+        </li>
+    </ul>
+    <p class="flow-text" data-localize="__MSG_helpAuthUserIdParagraphFive__">If the first account that Google Meet opened is your desired account, your AuthUser ID is 0 (and you probably
+        don't need this extension)</p>
+    <h5 data-localize="__MSG_helpForceRedirectTitle__">What is an Force Redirect?</h5>
+    <p class="flow-text" data-localize="__MSG_helpForceRedirectParagraphOne__">This option is required in order to handle invalid links with incorrect AuthUser inside it.</p>
+    <p class="flow-text" data-localize="__MSG_helpForceRedirectParagraphTwo__">This option start to redirect you into AuthUser ID, no matter which AuthUse ID provided in URL.</p>
+    <h5 data-localize="__MSG_helpHideAuthUserTitle__">What is an Hide AuthUser after redirection?</h5>
+    <p class="flow-text" data-localize="__MSG_helpHideAuthUserParagraphOne__">This option helps you to remove ?authuser= after redirection from url, so you can easily share it to others by copy/pasting.</p>
+</div>
+<script src="options.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
[i] add option to hide AuthUser from url after redirection
[i] prevent add AuthUser parameter for internal requests (css, js, fetch) of meet.google.com, handle only main frame
[i] use materialize.css for options window
[i] add locales (for ru and en)
[f] button stacked disabled after error and clear input to empty string